### PR TITLE
add note to readme that reagion should match aws cli config + adjust …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 
 deploy:
 	test -e node_modules || yarn; \
-	cdklocal bootstrap aws://000000000000/us-east-1; \
+	cdklocal bootstrap aws://000000000000/$$AWS_DEFAULT_REGION; \
 	cdklocal deploy
 
 ## Start LocalStack in detached mode

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cdklocal deploy
 ```
 
 *Note: Make sure your region is set to `us-east-1` in your AWS CLI configuration. Alternatively you can adjust the bootstrap command to match your region.
-The region in the Makefile is also set to `us-eat-1` and might need changing.*
+The region in the Makefile is also set to `us-east-1` and might need changing.*
 
 As an output of the last command, you will see the API Gateway endpoint URL. You can use this URL to test the API.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ cdklocal bootstrap aws://000000000000/us-east-1
 cdklocal deploy
 ```
 
+*Note: Make sure your region is set to `us-east-1` in your AWS CLI configuration. Alternatively you can adjust the bootstrap command to match your region.
+The region in the Makefile is also set to `us-eat-1` and might need changing.*
+
 As an output of the last command, you will see the API Gateway endpoint URL. You can use this URL to test the API.
 
 ### Testing the microservice


### PR DESCRIPTION
There are issues with bootstrapping if the region is not matching the one in the aws cli configurations. Add note in README file to signal potential problems + adjust Makefile to not use hardcoded region value