### PR TITLE
fix: update LocalStack license requirement and standardize CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install CDK
         run: |
@@ -38,13 +38,13 @@ jobs:
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           pip install localstack awscli-local[ver1]
           pip install terraform-local
           docker pull localstack/localstack-pro:latest
           # Start LocalStack in the background
-          EXTRA_CORS_ALLOWED_ORIGINS=* DEBUG=1 localstack start -d
+          EXTRA_CORS_ALLOWED_ORIGINS=* DEBUG=1 LOCALSTACK_AUTH_TOKEN=$LOCALSTACK_AUTH_TOKEN localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 15
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload the Diagnostic Report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diagnose.json.gz
           path: ./diagnose.json.gz

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ deploy:
 
 ## Start LocalStack in detached mode
 start:
-	localstack start -d
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
 
 ## Stop the Running LocalStack container
 stop:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deploy:
 ## Start LocalStack in detached mode
 start:
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) EXTRA_CORS_ALLOWED_ORIGINS=* localstack start -d
 
 ## Stop the Running LocalStack container
 stop:

--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ We are using the following AWS services and their features to build our infrastr
 
 ## Prerequisites
 
-- LocalStack Pro
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal`](https://github.com/localstack/awscli-local) wrapper.
 - [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://github.com/localstack/aws-cdk-local) wrapper.
-- [NodeJS v18.0.0](https://nodejs.org/en/download/) with `npm` package manager.
+- [Node.js](https://nodejs.org/en/download/) with `npm` package manager.
 
-Start LocalStack Pro by setting your `LOCALSTACK_AUTH_TOKEN` to activate the Pro features.
+## Start LocalStack
+
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
-export LOCALSTACK_AUTH_TOKEN=<your-api-key>
-EXTRA_CORS_ALLOWED_ORIGINS=* localstack start -d
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
 ```
 
 ## Instructions


### PR DESCRIPTION
## Summary

- Add auth guard to Makefile start target
- Replace LocalStack Pro references; add license bullet; add start section in README
- Upgrade checkout@v3->v4, setup-node@v3->v4, Node 18->22, upload-artifact@v3->v4
- Replace deprecated LOCALSTACK_API_KEY with LOCALSTACK_AUTH_TOKEN
